### PR TITLE
Refactor to stub LLM and add config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ A: In your home directory as `.pc_records_classifier_settings.pkl`.
 
 Pierce County IT | 2025
 """
+
+## Configuration
+Create a `config.yaml` or set environment variables to override defaults:
+
+```
+PCRC_MODEL=custom-model
+PCRC_OLLAMA_URL=http://localhost:11434
+PCRC_CONFIG=/path/to/config.yaml
+```
+
+The sample `config.yaml` may contain:
+
+```yaml
+model_name: pierce-county-records-classifier-phi2:latest
+ollama_url: http://localhost:11434
+```
+
+## Testing
+Run unit tests with `pytest`. A stub LLM is used so tests run offline.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,38 @@
+"""Application configuration module.
+
+Loads configuration from environment variables or an optional YAML file.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import yaml
+
+CONFIG_PATH = Path(os.environ.get("PCRC_CONFIG", "config.yaml"))
+
+@dataclass
+class AppConfig:
+    """Configuration options for the app."""
+
+    model_name: str = "pierce-county-records-classifier-phi2:latest"
+    ollama_url: str = "http://localhost:11434"
+
+
+def load_config() -> AppConfig:
+    """Load configuration from YAML file and environment variables."""
+    data = {}
+    if CONFIG_PATH.exists():
+        try:
+            with CONFIG_PATH.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:
+            data = {}
+    env_model = os.environ.get("PCRC_MODEL")
+    env_url = os.environ.get("PCRC_OLLAMA_URL")
+    if env_model:
+        data["model_name"] = env_model
+    if env_url:
+        data["ollama_url"] = env_url
+    return AppConfig(**data)
+
+CONFIG = load_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pdf2image>=1.16.0        # Convert PDF pages to images for OCR
 openpyxl>=3.1.2          # .xlsx
 setuptools>=80.9.0
 jsonschema>=4.24.0
+PyYAML>=6.0
 pandas>=2.2.2            # CSV/XLSX export, robust tabular handling
 pytest>=8.2.1            # Unit/integration tests
 

--- a/test_classification_stub.py
+++ b/test_classification_stub.py
@@ -1,0 +1,15 @@
+import tempfile
+from pathlib import Path
+from RecordsClassifierGui.logic.classification_engine_fixed import ClassificationEngine
+
+def test_classify_file_stub():
+    engine = ClassificationEngine(timeout_seconds=1)
+    with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as tf:
+        tf.write('sample text')
+        path = Path(tf.name)
+    try:
+        result = engine.classify_file(path)
+        assert result.model_determination == 'TRANSITORY'
+        assert result.confidence_score == 50
+    finally:
+        path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add config loader with YAML/env support
- stub out LLM interactions in `classification_engine_fixed`
- document configuration in README
- pin PyYAML in requirements
- add unit test for stubbed classification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd33ffb20832d9d98b5360e4975b1