### PR TITLE
Fix Last Modified mode

### DIFF
--- a/test_classification_stub.py
+++ b/test_classification_stub.py
@@ -1,4 +1,6 @@
 import tempfile
+import os
+import datetime
 from pathlib import Path
 from RecordsClassifierGui.logic.classification_engine_fixed import ClassificationEngine
 
@@ -13,3 +15,13 @@ def test_classify_file_stub():
         assert result.status
     finally:
         path.unlink(missing_ok=True)
+
+
+def test_last_modified_mode_auto_destroy(tmp_path):
+    engine = ClassificationEngine(timeout_seconds=1)
+    file_path = tmp_path / "old.txt"
+    file_path.write_text("old content")
+    old_time = (datetime.datetime.now() - datetime.timedelta(days=6 * 365 + 1)).timestamp()
+    os.utime(file_path, (old_time, old_time))
+    result = engine.classify_file(file_path, run_mode="Last Modified")
+    assert result.model_determination == "DESTROY"


### PR DESCRIPTION
## Summary
- default to `Classification` mode in GUI
- propagate run mode to backend engine
- refine Schedule 6 keyword heuristics
- test auto-destroy behaviour for Last Modified mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405f274980832d9fc376ab5e8e6e57