### PR TITLE
Fix folder change crash

### DIFF
--- a/RecordsClassifierGui/gui/screens.py
+++ b/RecordsClassifierGui/gui/screens.py
@@ -1197,6 +1197,11 @@ object adhering to the defined schema.
             title="Select folder containing files to classify"
         )
         if folder:
+            # Stop any active processing before switching folders
+            if self.processing:
+                self._stop_classification()
+                self.update_idletasks()
+
             # Update UI after dialog closes to avoid perceived freezing
             self.input_folder = folder
             self.folder_entry.delete(0, "end")


### PR DESCRIPTION
## Summary
- stop active classification before changing folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c2c05e9c832dbef970ef20bb7016