### PR TITLE
Improve Streamlit UI and classification engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 4. Export results to CSV
 5. Adjustable lines-per-file slider to control context size
 6. Responsive layout with dark mode and keyboard navigation
-7. **Last Modified mode** with a slider to choose how many years back to search
-8. Extensive Schedule 6 keyword list for accurate classification
+7. **Last Modified mode** with a slider shown only when this mode is selected
+8. Inline **RERUN** and **EXPORT** buttons appear after a job completes
+9. Extensive Schedule 6 keyword list for accurate classification
 
 ## System Requirements
 - Windows 10/11 or macOS/Linux with Python **3.8+**
@@ -46,7 +47,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 3. Watch the spinner and progress messages
 4. Read the decision and confidence score
 5. Switch to **Last Modified** mode and adjust the slider to list files older than your chosen number of years
-5. Save to CSV if desired
+6. When finished, use **RERUN** to analyze again or **EXPORT** to save results
 
 ## Minimal Path to Awesome (IT Admins)
 1. Review `config.yaml` or set environment variables for model location

--- a/RecordsClassifierGui/logic/classification_engine_fixed.py
+++ b/RecordsClassifierGui/logic/classification_engine_fixed.py
@@ -130,6 +130,19 @@ class LLMEngine:
         """Initialize real LLM clients when available."""
         logger.info("LLMEngine running in lightweight mode; no external service")
 
+    def _extract_snippet(self, content: str, keyword: str, window: int = 80) -> str:
+        """Return text snippet around a keyword or start of content."""
+        try:
+            if keyword:
+                lower = content.lower()
+                idx = lower.find(keyword.lower())
+                if idx != -1:
+                    start = max(0, idx - window // 2)
+                    return content[start:start + window].replace("\n", " ")
+            return content[:window].replace("\n", " ")
+        except Exception:
+            return content[:window].replace("\n", " ")
+
     def classify_with_llm(
         self,
         model: str,
@@ -167,30 +180,36 @@ class LLMEngine:
                     ),
                     "",
                 )
-                # Map OFFICIAL schedule to KEEP determination
                 determination = "KEEP" if best_label == "OFFICIAL" else best_label
                 base_conf = 50 + min(keyword_counts[best_label] * 10, 40)
+                snippet = self._extract_snippet(content, first_match)
+                insights = (
+                    f"The file includes the keyword '{first_match}', indicating a {determination.lower()} record."
+                    f" Example text: '{snippet}'."
+                    " This aligns with WA Schedule 6 guidance."
+                )
                 return {
                     "modelDetermination": determination,
                     "confidenceScore": base_conf,
-                    "contextualInsights": (
-                        f"Matched keyword '{first_match}'"
-                        if first_match
-                        else "Schedule 6 heuristic"
-                    ),
+                    "contextualInsights": insights,
                 }
 
-            snippet = text[:50]
+            snippet = self._extract_snippet(content, "")
+            insights = (
+                "No Schedule 6 keywords were found in the sampled text. "
+                f"The document starts with: '{snippet}'. "
+                "Based on this, the record appears transitory."
+            )
             return {
                 "modelDetermination": "TRANSITORY",
                 "confidenceScore": 50,
-                "contextualInsights": f"No Schedule 6 keywords found. Sample: '{snippet}'",
+                "contextualInsights": insights,
             }
 
         except Exception as exc:  # pragma: no cover - unexpected failures
             logger.error("Heuristic classification failed: %s", exc)
             return {
-                "modelDetermination": "ERROR",
+                "modelDetermination": "TRANSITORY",
                 "confidenceScore": 0,
                 "contextualInsights": f"Error: {exc}",
             }
@@ -308,7 +327,7 @@ class ClassificationEngine:
                     full_path=str(file_path.resolve()),
                     last_modified=mtime.isoformat(),
                     size_kb=size_kb,
-                    model_determination="SKIP",
+                    model_determination="TRANSITORY",
                     confidence_score=100,
                     contextual_insights=f"Excluded file type: {extension}",
                     status="skipped",
@@ -326,7 +345,7 @@ class ClassificationEngine:
                     full_path=str(file_path.resolve()),
                     last_modified=mtime.isoformat(),
                     size_kb=size_kb,
-                    model_determination="SKIP",
+                    model_determination="TRANSITORY",
                     confidence_score=100,
                     contextual_insights=f"Unsupported file type: {extension}",
                     status="skipped",
@@ -363,7 +382,7 @@ class ClassificationEngine:
                     full_path=str(file_path.resolve()),
                     last_modified=mtime.isoformat(),
                     size_kb=size_kb,
-                    model_determination="SKIP",
+                    model_determination="TRANSITORY",
                     confidence_score=100,
                     contextual_insights=f"File newer than {threshold_years} years",
                     status="skipped",
@@ -415,7 +434,7 @@ class ClassificationEngine:
                 full_path=str(file_path.resolve()),
                 last_modified=mtime.isoformat(),
                 size_kb=size_kb,
-                model_determination=llm_result.get("modelDetermination", "ERROR"),
+                model_determination=llm_result.get("modelDetermination", "TRANSITORY"),
                 confidence_score=confidence_score,
                 contextual_insights=llm_result.get("contextualInsights", ""),
                 status="success",
@@ -446,7 +465,7 @@ class ClassificationEngine:
                 full_path=str(file_path.resolve()),
                 last_modified=mtime.isoformat(),
                 size_kb=size_kb,
-                model_determination="ERROR",
+                model_determination="TRANSITORY",
                 confidence_score=0,
                 contextual_insights=f"Processing error: {msg[:200]}",
                 status="error",


### PR DESCRIPTION
## Summary
- show the last-modified slider only when that mode is selected
- add rerun/export buttons that appear after a job completes
- store classification results for export
- expand heuristic justification text
- map skip/error cases to TRANSITORY
- document new UI behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c78a8df4832db156f8c5785528d4