### PR TITLE
UI improvements and config enhancements

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,10 +23,13 @@ class AppConfig:
         Name of the model to use.
     ollama_url: str
         Base URL for the Ollama service.
+    batch_size: int
+        Number of files processed per batch.
     """
 
     model_name: str = "pierce-county-records-classifier-phi2:latest"
     ollama_url: str = "http://localhost:11434"
+    batch_size: int = 10
 
 
 def load_config() -> AppConfig:
@@ -47,10 +50,16 @@ def load_config() -> AppConfig:
             data = {}
     env_model = os.environ.get("PCRC_MODEL")
     env_url = os.environ.get("PCRC_OLLAMA_URL")
+    env_batch = os.environ.get("PCRC_BATCH_SIZE")
     if env_model:
         data["model_name"] = env_model
     if env_url:
         data["ollama_url"] = env_url
+    if env_batch:
+        try:
+            data["batch_size"] = int(env_batch)
+        except ValueError:
+            logger.warning("Invalid PCRC_BATCH_SIZE: %s", env_batch)
     return AppConfig(**data)
 
 CONFIG = load_config()

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,3 @@
 model_name: pierce-county-records-classifier-phi2:latest
 ollama_url: http://localhost:11434
+batch_size: 10

--- a/test_config.py
+++ b/test_config.py
@@ -7,6 +7,8 @@ def test_env_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("PCRC_CONFIG", str(cfg_file))
     monkeypatch.setenv("PCRC_MODEL", "b")
     monkeypatch.setenv("PCRC_OLLAMA_URL", "http://y")
+    monkeypatch.setenv("PCRC_BATCH_SIZE", "15")
     cfg = load_config()
     assert cfg.model_name == "b"
     assert cfg.ollama_url == "http://y"
+    assert cfg.batch_size == 15


### PR DESCRIPTION
## Summary
- allow batch size configuration via `config.yaml` and env vars
- add dropdown to filter classification results
- show cancel button in red
- store results for filtering and cleanup on new runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c9f86020832d93d724757cd93edc