### PR TITLE
Fix keyword detection and snippet handling

### DIFF
--- a/test_classification_stub.py
+++ b/test_classification_stub.py
@@ -118,3 +118,20 @@ def test_last_modified_skip_returns_na(tmp_path):
     result = engine.classify_file(file_path, run_mode="Last Modified")
     assert result.model_determination == "NA"
     assert result.status == "skipped"
+
+
+def test_transitory_when_no_keywords(tmp_path):
+    engine = ClassificationEngine(timeout_seconds=1)
+    file_path = tmp_path / "plain.txt"
+    file_path.write_text("just some random words")
+    result = engine.classify_file(file_path)
+    assert result.model_determination == "TRANSITORY"
+    assert "No Schedule 6 keywords" in result.contextual_insights
+
+
+def test_binary_snippet_placeholder(tmp_path):
+    engine = ClassificationEngine(timeout_seconds=1)
+    file_path = tmp_path / "bin.txt"
+    file_path.write_bytes(b"\x00\x01\x02" * 50)
+    result = engine.classify_file(file_path)
+    assert "[File is binary or unreadable]" in result.contextual_insights


### PR DESCRIPTION
## Summary
- sanitize text snippets to avoid binary garbage
- treat files with no keyword matches as transitory
- add tests for snippet sanitization and keyword logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d221a544832d8e7d47052981620c