### PR TITLE
Replace RERUN/EXPORT text buttons with icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 5. Adjustable lines-per-file slider to control context size
 6. Responsive layout with dark mode and keyboard navigation
 7. **Last Modified mode** with a slider shown only when this mode is selected
-8. Inline **RERUN** and **EXPORT** buttons appear after a job completes
+8. Inline rerun (↻) and export (⬇) buttons appear after a job completes
 9. Extensive Schedule 6 keyword list for accurate classification
 10. Clear results table showing **File Path** and a new **NA** category for skipped files
 
@@ -48,7 +48,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 3. Watch the spinner and progress messages
 4. Read the decision and confidence score
 5. Switch to **Last Modified** mode and adjust the slider to list files older than your chosen number of years
-6. When finished, use **RERUN** to analyze again or **EXPORT** to save results
+6. When finished, use the ↻ button to analyze again or the ⬇ button to save results
 
 ## Minimal Path to Awesome (IT Admins)
 1. Review `config.yaml` or set environment variables for model location

--- a/RecordsClassifierGui/gui/screens.py
+++ b/RecordsClassifierGui/gui/screens.py
@@ -840,10 +840,10 @@ class MainScreen(ctk.CTkFrame):
         # Inline RERUN and EXPORT buttons (initially hidden)
         self.rerun_btn = ctk.CTkButton(
             header_row,
-            text="RERUN",
-            font=(FONT_FAMILY, 11, "bold"),
+            text="↻",
+            font=(FONT_FAMILY, 16, "bold"),
             height=28,
-            width=80,
+            width=40,
             fg_color=theme.get("button_warning", "#FFC107"),
             text_color=theme.get("button_fg", "white"),
             hover_color=theme.get("button_warning_hover", "#e0a800"),
@@ -854,10 +854,10 @@ class MainScreen(ctk.CTkFrame):
 
         self.export_btn = ctk.CTkButton(
             header_row,
-            text="EXPORT",
-            font=(FONT_FAMILY, 11, "bold"),
+            text="⬇",
+            font=(FONT_FAMILY, 16, "bold"),
             height=28,
-            width=80,
+            width=40,
             fg_color=theme.get("button_success", "#28A745"),
             text_color=theme.get("button_fg", "white"),
             hover_color=theme.get("button_success_hover", "#218838"),

--- a/RecordsClassifierGui/gui/screens_optimized.py
+++ b/RecordsClassifierGui/gui/screens_optimized.py
@@ -735,10 +735,10 @@ class MainScreen(ctk.CTkFrame):
         # Inline RERUN and EXPORT buttons (initially hidden)
         self.rerun_btn = ctk.CTkButton(
             header_row,
-            text="RERUN",
-            font=(FONT_FAMILY, 11, "bold"),
+            text="↻",
+            font=(FONT_FAMILY, 16, "bold"),
             height=28,
-            width=80,
+            width=40,
             fg_color=theme.get('button_warning', '#FFC107'),
             text_color=theme.get('button_fg', 'white'),
             hover_color=theme.get('button_warning_hover', '#e0a800'),
@@ -749,10 +749,10 @@ class MainScreen(ctk.CTkFrame):
 
         self.export_btn = ctk.CTkButton(
             header_row,
-            text="EXPORT",
-            font=(FONT_FAMILY, 11, "bold"),
+            text="⬇",
+            font=(FONT_FAMILY, 16, "bold"),
             height=28,
-            width=80,
+            width=40,
             fg_color=theme.get('button_success', '#28A745'),
             text_color=theme.get('button_fg', 'white'),
             hover_color=theme.get('button_success_hover', '#218838'),

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -115,13 +115,13 @@ def main() -> None:
     if st.session_state.get("last_file") and not st.session_state.get("running"):
         col1, col2 = st.columns(2)
         with col1:
-            if st.button("RERUN", help="Run classification again on the last uploaded file"):
+            if st.button("↻", help="Run classification again on the last uploaded file"):
                 classify(st.session_state["last_file"], engine, mode, years)
         with col2:
             result = st.session_state.get("last_result")
             if result:
                 st.download_button(
-                    "EXPORT",
+                    "⬇",
                     data=str(result),
                     file_name="classification.json",
                     help="Download the latest classification result",


### PR DESCRIPTION
## Summary
- show arrow icons for rerun and export buttons in both tkinter and Streamlit UIs
- update README steps to mention the new icons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d2c1fb9c832dbc98384b4065e827