### PR TITLE
Enhance UI with live stats and entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 9. Extensive Schedule 6 keyword list for accurate classification
 10. Clear results table showing **File Path** and a new **NA** category for skipped files
 11. Dedicated **How It Works** page with a plain‑language walkthrough
+12. Live results table with real-time progress and summary stats
 
 ## System Requirements
 - Windows 10/11 or macOS/Linux with Python **3.8+**
@@ -40,7 +41,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 3. Optionally edit `config.yaml` to customize the model or Ollama URL
 4. Ensure Tesseract and (on Windows) antiword are on your `PATH`
 5. Run `Deploy.ps1` once to load the model
-6. Start the UI with `python run_app.py` or `streamlit run streamlit_app.py`
+6. Start the UI with `python run_app.py` or `streamlit run app.py`
    (edit `.streamlit/config.toml` to customize the theme)
 
 ## Minimal Path to Awesome (Users)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,163 @@
+"""Streamlit entrypoint with live progress and stats."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import streamlit as st
+from streamlit.logger import get_logger
+
+from RecordsClassifierGui.logic.classification_engine_fixed import (
+    ClassificationEngine,
+    classify_directory,
+    ClassificationResult,
+)
+from config import CONFIG
+from version import __version__
+from streamlit_helpers import load_file_content, compute_stats
+
+logger = get_logger(__name__)
+
+
+@st.cache_resource
+def get_engine() -> ClassificationEngine:
+    """Create or return the cached engine."""
+    return ClassificationEngine()
+
+
+def _append_result(result: ClassificationResult) -> None:
+    """Store a classification result for later display."""
+    st.session_state.setdefault("results", [])
+    st.session_state["results"].append(
+        {
+            "File": result.file_name,
+            "Size": result.size_kb,
+            "Modified": result.last_modified,
+            "Classification": result.model_determination,
+            "Confidence": result.confidence_score,
+            "Status": result.status,
+            "Contextual Insights": result.contextual_insights,
+            "File Path": result.full_path,
+        }
+    )
+
+
+def _update_table(placeholder: st.delta_generator.DeltaGenerator) -> None:
+    """Render results in the given placeholder."""
+    df = pd.DataFrame(st.session_state.get("results", []))
+    if df.empty:
+        placeholder.empty()
+        return
+    placeholder.dataframe(df, use_container_width=True)
+    st.session_state["stats"] = compute_stats(st.session_state["results"])
+
+
+def _process_paths(
+    paths: Iterable[Path],
+    engine: ClassificationEngine,
+    mode: str,
+    years: int | None,
+    table_ph: st.delta_generator.DeltaGenerator,
+) -> None:
+    """Classify provided paths and update the table live."""
+    paths = list(paths)
+    progress = st.progress(0)
+    for idx, path in enumerate(paths, start=1):
+        with st.spinner(f"Processing {path.name}"):
+            try:
+                result = engine.classify_file(path, run_mode=mode, threshold_years=years or 6)
+            except Exception as exc:  # pragma: no cover - UI feedback only
+                logger.exception("Classification failed")
+                st.error(f"Failed to classify {path.name}: {exc}")
+                continue
+        _append_result(result)
+        _update_table(table_ph)
+        progress.progress(idx / len(paths))
+    progress.empty()
+
+
+def _run_folder(
+    path: Path,
+    engine: ClassificationEngine,
+    mode: str,
+    years: int | None,
+    table_ph: st.delta_generator.DeltaGenerator,
+) -> None:
+    """Classify every supported file in ``path`` recursively."""
+    if not path.exists() or not path.is_dir():
+        st.error("Folder does not exist")
+        return
+
+    results = classify_directory(path, engine=engine, run_mode=mode, threshold_years=years or 6)
+    for res in results:
+        _append_result(res)
+        _update_table(table_ph)
+
+
+def _show_stats() -> None:
+    """Display summary metrics in the footer."""
+    stats = st.session_state.get("stats")
+    if not stats:
+        return
+    cols = st.columns(4)
+    cols[0].metric("Processed", stats["total"])
+    cols[1].metric("Success", stats["success"])
+    cols[2].metric("Skipped", stats["skipped"])
+    cols[3].metric("Errors", stats["error"])
+
+
+
+def main() -> None:
+    """Run the Streamlit UI."""
+    st.set_page_config(page_title="Records Classifier", page_icon="📄", layout="wide")
+    st.sidebar.title("Pierce County Records Classifier")
+    st.sidebar.write(f"Version {__version__}")
+
+    engine = get_engine()
+
+    mode = st.sidebar.radio(
+        "Mode",
+        options=["Classification", "Last Modified"],
+        help="Choose 'Classification' to analyze a document or 'Last Modified' to auto-destroy old files.",
+    )
+
+    years: int | None = None
+    if mode == "Last Modified":
+        years = st.sidebar.slider(
+            "Last Modified Threshold (years)",
+            1,
+            10,
+            6,
+            help="Files older than this will be classified as DESTROY.",
+        )
+
+    st.title("Electronic Records Classifier")
+    st.write(f"Model: {CONFIG.model_name}")
+
+    uploads = st.file_uploader(
+        "Upload files",
+        accept_multiple_files=True,
+        help="Supported formats: PDF, DOCX, images, etc.",
+    )
+
+    table_ph = st.empty()
+
+    if uploads:
+        paths: list[Path] = []
+        for file in uploads:
+            p = load_file_content(file)
+            if p:
+                paths.append(p)
+        _process_paths(paths, engine, mode, years, table_ph)
+
+    folder = st.text_input("Or enter a folder path to scan")
+    if folder and st.button("Scan Folder"):
+        _run_folder(Path(folder), engine, mode, years, table_ph)
+
+    _update_table(table_ph)
+    _show_stats()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_app.py
+++ b/run_app.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    """Run ``streamlit_app.py`` using the current Python interpreter."""
+    """Run ``app.py`` using the current Python interpreter."""
     logging.basicConfig(level=logging.INFO)
     try:
         subprocess.run([
@@ -16,7 +16,7 @@ def main() -> None:
             "-m",
             "streamlit",
             "run",
-            "streamlit_app.py",
+            "app.py",
         ], check=True)
     except Exception as exc:
         logger.exception("Failed to launch Streamlit", exc_info=exc)

--- a/streamlit_helpers.py
+++ b/streamlit_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Iterable
 
 import streamlit as st
 
@@ -40,3 +40,54 @@ def load_file_content(uploaded_file) -> Optional[Path]:
         logger.exception("Error saving uploaded file")
         st.error(f"Failed to save file: {exc}")
         return None
+
+
+def compute_stats(results: Iterable[dict]) -> dict:
+    """Return summary statistics for ``results``.
+
+    Parameters
+    ----------
+    results : Iterable[dict]
+        Rows as dictionaries containing ``Classification`` and ``Status`` keys.
+
+    Returns
+    -------
+    dict
+        Counts of determinations and statuses.
+    """
+
+    summary = {
+        "total": 0,
+        "keep": 0,
+        "destroy": 0,
+        "transitory": 0,
+        "na": 0,
+        "success": 0,
+        "error": 0,
+        "skipped": 0,
+    }
+
+    for row in results:
+        summary["total"] += 1
+        cls = str(row.get("Classification", "")).lower()
+        match cls:
+            case "keep":
+                summary["keep"] += 1
+            case "destroy":
+                summary["destroy"] += 1
+            case "transitory":
+                summary["transitory"] += 1
+            case "na":
+                summary["na"] += 1
+
+        status = str(row.get("Status", "")).lower()
+        match status:
+            case "success":
+                summary["success"] += 1
+            case "error":
+                summary["error"] += 1
+            case "skipped":
+                summary["skipped"] += 1
+
+    return summary
+

--- a/test_streamlit_helpers.py
+++ b/test_streamlit_helpers.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import tempfile
-from streamlit_helpers import sanitize_filename, load_file_content
+from streamlit_helpers import sanitize_filename, load_file_content, compute_stats
 
 class DummyUpload:
     def __init__(self, name: str, data: bytes):
@@ -22,3 +22,21 @@ def test_load_file_content(tmp_path: Path):
     path = load_file_content(dummy)
     assert path is not None
     assert path.read_bytes() == b'hi'
+
+
+def test_compute_stats():
+    data = [
+        {"Classification": "KEEP", "Status": "success"},
+        {"Classification": "DESTROY", "Status": "success"},
+        {"Classification": "NA", "Status": "skipped"},
+        {"Classification": "TRANSITORY", "Status": "error"},
+    ]
+    stats = compute_stats(data)
+    assert stats["total"] == 4
+    assert stats["keep"] == 1
+    assert stats["destroy"] == 1
+    assert stats["na"] == 1
+    assert stats["transitory"] == 1
+    assert stats["success"] == 2
+    assert stats["skipped"] == 1
+    assert stats["error"] == 1


### PR DESCRIPTION
## Summary
- add `app.py` with live-updating table and footer metrics
- cache the engine and compute result statistics
- update `streamlit_helpers` with `compute_stats`
- provide tests for new helper
- run app via `app.py`
- document new features in README

## Testing
- `pre-commit run --all-files` *(fails: InvalidConfigError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e81456bc832dbe2d87c9874f844a