### PR TITLE
UI tweaks and folder-first workflow

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,11 +25,14 @@ class AppConfig:
         Base URL for the Ollama service.
     batch_size: int
         Number of files processed per batch.
+    max_lines: int
+        Number of lines of content to pass to the model.
     """
 
     model_name: str = "pierce-county-records-classifier-phi2:latest"
     ollama_url: str = "http://localhost:11434"
     batch_size: int = 10
+    max_lines: int = 100
 
 
 def load_config() -> AppConfig:
@@ -51,6 +54,7 @@ def load_config() -> AppConfig:
     env_model = os.environ.get("PCRC_MODEL")
     env_url = os.environ.get("PCRC_OLLAMA_URL")
     env_batch = os.environ.get("PCRC_BATCH_SIZE")
+    env_max_lines = os.environ.get("PCRC_MAX_LINES")
     if env_model:
         data["model_name"] = env_model
     if env_url:
@@ -60,6 +64,11 @@ def load_config() -> AppConfig:
             data["batch_size"] = int(env_batch)
         except ValueError:
             logger.warning("Invalid PCRC_BATCH_SIZE: %s", env_batch)
+    if env_max_lines:
+        try:
+            data["max_lines"] = int(env_max_lines)
+        except ValueError:
+            logger.warning("Invalid PCRC_MAX_LINES: %s", env_max_lines)
     return AppConfig(**data)
 
 CONFIG = load_config()

--- a/test_config.py
+++ b/test_config.py
@@ -8,7 +8,9 @@ def test_env_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("PCRC_MODEL", "b")
     monkeypatch.setenv("PCRC_OLLAMA_URL", "http://y")
     monkeypatch.setenv("PCRC_BATCH_SIZE", "15")
+    monkeypatch.setenv("PCRC_MAX_LINES", "200")
     cfg = load_config()
     assert cfg.model_name == "b"
     assert cfg.ollama_url == "http://y"
     assert cfg.batch_size == 15
+    assert cfg.max_lines == 200


### PR DESCRIPTION
## Summary
- switch from file upload to folder-based scanning
- center the logo in the sidebar
- add slider for max lines to pass to the model
- support `max_lines` in config and env vars
- test config overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f3ef83b8832dadc8fda5236676c5