### PR TITLE
Switch config to pydantic

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@
 Loads configuration from environment variables or an optional YAML file.
 """
 
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 from pathlib import Path
 import logging
 import os
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path(os.environ.get("PCRC_CONFIG", "config.yaml"))
 
-@dataclass
-class AppConfig:
+class AppConfig(BaseModel):
     """Configuration options for the app.
 
     Attributes
@@ -29,10 +28,24 @@ class AppConfig:
         Number of lines of content to pass to the model.
     """
 
-    model_name: str = "pierce-county-records-classifier-phi2:latest"
-    ollama_url: str = "http://localhost:11434"
-    batch_size: int = 10
-    max_lines: int = 100
+    model_name: str = Field(
+        default="pierce-county-records-classifier-phi2:latest",
+        description="Name of the model to use.",
+    )
+    ollama_url: str = Field(
+        default="http://localhost:11434",
+        description="Base URL for the Ollama service.",
+    )
+    batch_size: int = Field(
+        default=10,
+        description="Number of files processed per batch.",
+        ge=1,
+    )
+    max_lines: int = Field(
+        default=100,
+        description="Number of lines of content to pass to the model.",
+        ge=1,
+    )
 
 
 def load_config() -> AppConfig:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ openpyxl>=3.1.2          # .xlsx
 setuptools>=80.9.0
 jsonschema>=4.24.0
 PyYAML>=6.0
+pydantic>=2.7.0
 pandas>=2.2.2            # CSV/XLSX export, robust tabular handling
 pytest>=8.2.1            # Unit/integration tests
 streamlit>=1.35.0        # Web-based user interface


### PR DESCRIPTION
## Summary
- use `pydantic.BaseModel` for `AppConfig`
- add `pydantic` to requirements

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6840fa4647dc832d863f46527d409280