### PR TITLE
Improve folder picker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
 - **Missing model**: run `Deploy.ps1` again or contact IT
 - **OCR errors**: verify Tesseract is installed and on `PATH`
 - **App will not start**: reinstall using the latest installer
+- **Folder picker unavailable**: type the folder path manually in the sidebar
 
 ## Building an Installer
 1. Install Inno Setup and PyInstaller

--- a/app.py
+++ b/app.py
@@ -31,10 +31,15 @@ def _log_message(msg: str, placeholder: Optional[st.delta_generator.DeltaGenerat
 
 
 def _pick_directory() -> Optional[str]:
-    """Open a native folder dialog if possible."""
+    """Return a selected folder path or ``None`` when unavailable."""
     try:
         from tkinter import Tk, filedialog
+    except Exception as exc:  # pragma: no cover - import may fail on headless systems
+        logger.warning("Tkinter unavailable: %s", exc)
+        st.warning("Folder picker unavailable. Please type the path manually.")
+        return None
 
+    try:
         root = Tk()
         root.withdraw()
         path = filedialog.askdirectory()
@@ -42,7 +47,7 @@ def _pick_directory() -> Optional[str]:
         return path or None
     except Exception as exc:  # pragma: no cover - UI feedback only
         logger.warning("Folder picker failed: %s", exc)
-        st.error("Folder picker not available")
+        st.warning("Folder picker unavailable. Please type the path manually.")
         return None
 
 

--- a/test_pick_directory.py
+++ b/test_pick_directory.py
@@ -1,0 +1,15 @@
+import sys
+from app import _pick_directory
+
+class DummyTk:
+    def __init__(self):
+        pass
+    def withdraw(self):
+        pass
+    def destroy(self):
+        pass
+
+def test_pick_directory_no_tk(monkeypatch):
+    monkeypatch.setitem(sys.modules, "tkinter", None)
+    result = _pick_directory()
+    assert result is None


### PR DESCRIPTION
## Summary
- gracefully handle missing `tkinter` in app folder picker
- document manual path entry when folder picker is unavailable
- add unit test covering no-tkinter case

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_684101a22b18832db24489bdaa167eb0