### PR TITLE
Add Windows build environment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The Records Classifier sorts documents into **Keep**, **Destroy**, or **Transito
    (or run `python run_app.py` if Streamlit isn't on your PATH)
 7. Optional: `python run_local.py --model <name>` to launch the local LLM API
 
+### Windows Build Helper
+If `cargo check` fails on Windows because the MSVC environment isn't loaded,
+run `scripts/setup_windows_env.ps1` in a PowerShell prompt before building.
+The script uses `vswhere` to locate Visual Studio Build Tools and sets the
+required variables for the current session.
+
 ### Running the Local LLM
 `run_local.py` downloads models to `models/` and serves a simple `/generate`
 endpoint using FastAPI and Uvicorn. Use `--quant 4` or `--quant 8` for

--- a/scripts/setup_windows_env.ps1
+++ b/scripts/setup_windows_env.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+  Prepare a Windows shell for building this project.
+.DESCRIPTION
+  Detects Visual Studio Build Tools, Node.js and Rust.
+  Sets MSVC environment variables using `vswhere` if necessary.
+  Run this script in every new PowerShell session before invoking `cargo`.
+#>
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Command($Name, $Url) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Write-Host "ERROR: '$Name' not found. Please install from $Url" -ForegroundColor Red
+        exit 1
+    }
+}
+
+Assert-Command 'cargo' 'https://rustup.rs/'
+Assert-Command 'node' 'https://nodejs.org/'
+Assert-Command 'vswhere' 'https://aka.ms/vswhere'
+
+# Discover latest VS Build Tools
+$vsPath = & vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if (-not $vsPath) {
+    Write-Host 'Visual Studio Build Tools not found. Install the "Desktop development with C++" workload.' -ForegroundColor Red
+    exit 1
+}
+
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+if (-not (Test-Path $vcvars)) {
+    Write-Host "Unable to locate vcvars64.bat at $vcvars" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'Configuring MSVC environment...'
+cmd /c "`"$vcvars`"" > $null
+
+$required = @('VCINSTALLDIR','VisualStudioVersion','WindowsSdkDir')
+$missing = @()
+foreach ($r in $required) {
+    if (-not $env:$r) { $missing += $r }
+}
+if ($missing.Count -gt 0) {
+    Write-Host "ERROR: the following environment variables are missing: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'Environment ready. Run your cargo commands now.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add `scripts/setup_windows_env.ps1` to configure Visual Studio build tools in a PowerShell session
- document script usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68432e14bb24832da8c815ef4b22a925